### PR TITLE
feat(metrics): добавлен эндпоинт /metrics, ServiceMonitor, обновлена …

### DIFF
--- a/helm/alert-history/Chart.yaml
+++ b/helm/alert-history/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: alert-history
-version: 0.1.0
+version: 0.2.0
 description: Alertmanager Alert History Webhook Receiver
 appVersion: "1.0"

--- a/helm/alert-history/templates/servicemonitor.yaml
+++ b/helm/alert-history/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "alert-history.fullname" . }}
+  labels:
+    release: {{ .Release.Name }}
+    app: {{ include "alert-history.name" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "alert-history.name" . }}
+      release: {{ .Release.Name }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyYAML>=6.0
 fastapi
 uvicorn
 jinja2
+prometheus_client


### PR DESCRIPTION
What’s Changed
Added Prometheus /metrics endpoint to the FastAPI service (exports webhook events, errors, DB stats, request latency, etc).
Added ServiceMonitor to the Helm chart for automatic metrics scraping (compatible with kube-prometheus-stack).
Updated documentation (Helm README) with monitoring/metrics details and ServiceMonitor example.
Bumped chart version to 0.2.0.
Why
To enable Prometheus/Grafana monitoring of alert history service health and alert/event dynamics.
To provide out-of-the-box integration with Kubernetes monitoring stacks.
Notes
Docker image needs to be rebuilt (new dependency: prometheus_client).
ServiceMonitor will be created automatically if Prometheus Operator is present in the cluster.
