### PR TITLE
Feature/retention period

### DIFF
--- a/alert_history_grafana_dashboard.json
+++ b/alert_history_grafana_dashboard.json
@@ -1,0 +1,127 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1620000000000,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "title": "Firing Alerts Over Time",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (alertname) (increase(alert_history_webhook_events_total{status=\"firing\"}[5m]))",
+          "legendFormat": "{{alertname}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {"defaults": {}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "title": "Resolved Alerts Over Time",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (alertname) (increase(alert_history_webhook_events_total{status=\"resolved\"}[5m]))",
+          "legendFormat": "{{alertname}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {"defaults": {}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "id": 3,
+      "title": "Top Noisiest Alerts (24h)",
+      "type": "barchart",
+      "targets": [
+        {
+          "expr": "topk(10, sum by (alertname) (increase(alert_history_webhook_events_total[24h])))",
+          "legendFormat": "{{alertname}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {"defaults": {}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "id": 4,
+      "title": "Request Latency (95th percentile)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(alert_history_request_latency_seconds_bucket[5m])) by (le, endpoint))",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {"defaults": {}, "overrides": []},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 16},
+      "id": 5,
+      "title": "Flapping Alerts (status changes, 24h)",
+      "type": "barchart",
+      "targets": [
+        {
+          "expr": "topk(10, sum by (alertname) (increase(alert_history_webhook_events_total[24h])))",
+          "legendFormat": "{{alertname}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": ["alertmanager", "metrics", "prometheus", "alerts"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Alert History Service",
+  "uid": null,
+  "version": 1
+}

--- a/alert_history_service.py
+++ b/alert_history_service.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI, Request, Query
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional, List
 from fastapi import HTTPException
 from fastapi.templating import Jinja2Templates
@@ -25,6 +25,7 @@ import threading
 import time
 
 DB_PATH = os.environ.get("ALERT_HISTORY_DB", "alert_history.sqlite3")
+RETENTION_DAYS = int(os.environ.get("RETENTION_DAYS", "30"))
 
 app = FastAPI(title="Alertmanager Alert History Service")
 
@@ -432,3 +433,23 @@ def fill_namespaces():
 @app.get("/metrics")
 def metrics():
     return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+# --- CLEANUP FUNCTION ---
+def cleanup_old_data():
+    """Удаляет данные старше RETENTION_DAYS дней"""
+    while True:
+        try:
+            cutoff_date = (datetime.utcnow() - timedelta(days=RETENTION_DAYS)).isoformat()
+            with get_db() as conn:
+                c = conn.cursor()
+                c.execute("DELETE FROM alert_history WHERE updatedAt < ?", (cutoff_date,))
+                deleted = c.rowcount
+                conn.commit()
+                if deleted > 0:
+                    print(f"Cleaned up {deleted} old records")
+        except Exception as e:
+            print(f"Error during cleanup: {e}")
+        time.sleep(3600)  # Проверяем каждый час
+
+# Запускаем очистку в отдельном потоке
+threading.Thread(target=cleanup_old_data, daemon=True).start()

--- a/alert_history_service.py
+++ b/alert_history_service.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-Alert History Service для Alertmanager webhook:
-- POST /webhook — приём событий алертов (firing/resolved)
-- GET /history — выдача истории алертов (фильтры: alertname, status, fingerprint, время)
-- GET /report — аналитика по истории алертов
-- Хранение истории в SQLite (stateful)
+Alert History Service for Alertmanager webhook:
+- POST /webhook — receive alert events (firing/resolved)
+- GET /history — get alert history (filters: alertname, status, fingerprint, time)
+- GET /report — get alert analytics
+- SQLite storage (stateful)
 """
 
 import os
@@ -436,7 +436,7 @@ def metrics():
 
 # --- CLEANUP FUNCTION ---
 def cleanup_old_data():
-    """Удаляет данные старше RETENTION_DAYS дней"""
+    """Delete data older than RETENTION_DAYS"""
     while True:
         try:
             cutoff_date = (datetime.utcnow() - timedelta(days=RETENTION_DAYS)).isoformat()
@@ -449,7 +449,7 @@ def cleanup_old_data():
                     print(f"Cleaned up {deleted} old records")
         except Exception as e:
             print(f"Error during cleanup: {e}")
-        time.sleep(3600)  # Проверяем каждый час
+        time.sleep(3600)  # Check every hour
 
-# Запускаем очистку в отдельном потоке
+# Start cleanup in a separate thread
 threading.Thread(target=cleanup_old_data, daemon=True).start()

--- a/helm/alert-history/Chart.yaml
+++ b/helm/alert-history/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v2
 name: alert-history
-version: 0.2.0
-description: Alertmanager Alert History Webhook Receiver
-appVersion: "1.0"
+description: A Helm chart for Alert History Service
+type: application
+version: 0.1.1
+appVersion: "0.1.1"

--- a/helm/alert-history/README.md
+++ b/helm/alert-history/README.md
@@ -1,50 +1,50 @@
 # alert-history
 
-Helm-чарт для деплоя Alertmanager Alert History Webhook Receiver
+Helm-chart for deploying Alertmanager Alert History Webhook Receiver
 
-## Возможности
-- Приём webhook событий от Alertmanager (`/webhook`)
-- Хранение истории алертов в SQLite (stateful PVC)
-- Выдача истории по HTTP (`/history`)
+## Features
+- Receiving webhook events from Alertmanager (`/webhook`)
+- Storing alert history in SQLite (stateful PVC)
+- Providing history via HTTP (`/history`)
 
-## Мониторинг и метрики
+## Monitoring and Metrics
 
-- Сервис экспортирует метрики Prometheus на эндпоинте `/metrics` (порт 8080).
-- Включён ServiceMonitor для автоматического сбора метрик (если установлен kube-prometheus-stack).
-- Экспортируются метрики:
-  - `alert_history_webhook_events_total` — события webhook (по статусу, alertname, namespace)
-  - `alert_history_webhook_errors_total` — ошибки обработки webhook
-  - `alert_history_history_queries_total` — запросы к истории
-  - `alert_history_report_queries_total` — запросы к аналитике
-  - `alert_history_db_alerts` — количество алертов в базе
-  - `alert_history_request_latency_seconds` — время обработки запросов (гистограмма)
+- Service exports Prometheus metrics on the `/metrics` endpoint (port 8080).
+- ServiceMonitor is enabled for automatic metric collection (if kube-prometheus-stack is installed).
+- Metrics exported:
+  - `alert_history_webhook_events_total` — webhook events (by status, alertname, namespace)
+  - `alert_history_webhook_errors_total` — webhook processing errors
+  - `alert_history_history_queries_total` — history queries
+  - `alert_history_report_queries_total` — report queries
+  - `alert_history_db_alerts` — number of alerts in the database
+  - `alert_history_request_latency_seconds` — request processing time (histogram)
 
-## Быстрый старт
+## Quick Start
 
-1. Соберите Docker-образ:
+1. Build Docker image:
    ```bash
    docker build -t alert-history:latest .
    ```
 
-2. Залейте образ в ваш реестр (если нужно):
+2. Push image to your registry (if needed):
    ```bash
    docker tag alert-history:latest <your-registry>/alert-history:latest
    docker push <your-registry>/alert-history:latest
    ```
 
-3. Установите Helm-чарт:
+3. Install Helm chart:
    ```bash
    helm install alert-history ./helm/alert-history \
      --set image.repository=<your-registry>/alert-history \
      --set image.tag=latest
    ```
 
-4. Пробросьте порт для локального теста:
+4. Forward port for local test:
    ```bash
    kubectl port-forward svc/alert-history-alert-history 8080:8080
    ```
 
-5. Настройте Alertmanager webhook:
+5. Configure Alertmanager webhook:
    ```yaml
    receivers:
      - name: 'alert-history'
@@ -52,26 +52,26 @@ Helm-чарт для деплоя Alertmanager Alert History Webhook Receiver
          - url: 'http://alert-history-alert-history:8080/webhook'
    ```
 
-## Пример запроса истории
+## Example History Query
 
 ```bash
 curl 'http://localhost:8080/history?alertname=CPUThrottlingHigh&status=firing&since=2024-06-01T00:00:00'
 ```
 
-## Переменные values.yaml
-- `image.repository` — имя образа
-- `image.tag` — тег образа
-- `persistence.enabled` — включить PVC
-- `persistence.size` — размер PVC
-- `service.port` — порт сервиса
-- `retentionDays` — период хранения истории алертов в днях (по умолчанию 30)
+## values.yaml Variables
+- `image.repository` — image name
+- `image.tag` — image tag
+- `persistence.enabled` — enable PVC
+- `persistence.size` — PVC size
+- `service.port` — service port
+- `retentionDays` — alert history retention period in days (default: 30)
 
 ## PVC
-История алертов хранится в `/data/alert_history.sqlite3` (persistent volume). Старые записи автоматически удаляются через `retentionDays` дней.
+Alert history is stored in `/data/alert_history.sqlite3` (persistent volume). Old records are automatically deleted after `retentionDays` days.
 
-## Пример ServiceMonitor
+## ServiceMonitor Example
 
-ServiceMonitor создаётся автоматически:
+ServiceMonitor is created automatically:
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -92,4 +92,4 @@ spec:
 
 ---
 
-**Автор:** @your-team
+**Author:** @your-team

--- a/helm/alert-history/README.md
+++ b/helm/alert-history/README.md
@@ -64,9 +64,10 @@ curl 'http://localhost:8080/history?alertname=CPUThrottlingHigh&status=firing&si
 - `persistence.enabled` — включить PVC
 - `persistence.size` — размер PVC
 - `service.port` — порт сервиса
+- `retentionDays` — период хранения истории алертов в днях (по умолчанию 30)
 
 ## PVC
-История алертов хранится в `/data/alert_history.sqlite3` (persistent volume).
+История алертов хранится в `/data/alert_history.sqlite3` (persistent volume). Старые записи автоматически удаляются через `retentionDays` дней.
 
 ## Пример ServiceMonitor
 

--- a/helm/alert-history/templates/deployment.yaml
+++ b/helm/alert-history/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
           env:
             - name: ALERT_HISTORY_DB
               value: "/data/alert_history.sqlite3"
+            - name: RETENTION_DAYS
+              value: {{ .Values.retentionDays | quote }}
           volumeMounts:
             - name: data
               mountPath: /data

--- a/helm/alert-history/values.yaml
+++ b/helm/alert-history/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ipiton/alertanalize
-  tag: 0.1.0
+  tag: 0.1.1
   pullPolicy: IfNotPresent
 
 service:
@@ -10,6 +10,9 @@ service:
   port: 8080
 
 resources: {}
+
+# Retention period in days for alert history
+retentionDays: 30
 
 persistence:
   enabled: true


### PR DESCRIPTION
# Add Configurable Data Retention Period

## Changes
- Added configurable retention period via `RETENTION_DAYS` environment variable
- Default value set to 30 days
- Automatic cleanup of old data every hour
- Ability to modify retention period through Helm values

## Technical Details
- Added `cleanup_old_data()` function for automatic cleanup
- Added environment variable to deployment
- Added `retentionDays` parameter to values.yaml
- Updated documentation

## Usage
When installing/updating the Helm chart, you can specify the retention period:
```bash
helm install alert-history ./helm/alert-history --set retentionDays=60  # for 60 days
```

## Versions
- Chart version: 0.1.1
- App version: 0.1.1